### PR TITLE
Fix incorrect package names

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ Uses BAML with various LLM models for generation.
 The model can be specified via command-line argument.
 
 Requires:
-    pip install pydantic MIDIUtil baml-client python-dotenv music21
+    pip install pydantic MIDIUtil baml-py python-dotenv music21
     LilyPond installed and in PATH for sheet music generation
 """
 import dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ openai
 pydantic
 MIDIUtil
 baml-py
-dotenv
+python-dotenv
+music21


### PR DESCRIPTION
## Summary
- add missing packages to requirements
- correct docs to show `baml-py` instead of `baml-client`

## Testing
- `python -m py_compile main.py melody_generator.py sheet_music_generator.py list_models.py`